### PR TITLE
Add sample check overdue borrowings

### DIFF
--- a/borrowing_service/tasks.py
+++ b/borrowing_service/tasks.py
@@ -30,7 +30,7 @@ def notify_overdue_borrowings(self):
 
     for message in messages:
         try:
-            logger.info(f"Processing notify_overdue_borrowings")
+            logger.info("Processing notify_overdue_borrowings")
             success = send_telegram_message(message)
             if not success:
                 logger.error("Failed to send Telegram notification")

--- a/borrowing_service/tasks.py
+++ b/borrowing_service/tasks.py
@@ -1,0 +1,40 @@
+import logging
+
+from celery import Task, shared_task
+
+from borrowing_service.utils import today_overdue_borrowings
+from notifications_service.utils import send_telegram_message
+
+
+# Used for Celery logging via:
+# celery -A core.celery_config worker -l info
+# Can be used in core/settings.py if needed
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3)
+def notify_overdue_borrowings(self):
+    today, overdue_borrowings = today_overdue_borrowings()
+    messages = []
+    if overdue_borrowings:
+        for borrowing in overdue_borrowings:
+            messages.append(
+                f"{today} Overdue Borrowing:\n"
+                f"Borrowing ID: {borrowing.id}\n"
+                f"User: {borrowing.user.email}\n"
+                f"Book: {borrowing.book.title}"
+            )
+    else:
+        messages.append(f"No borrowings overdue for {today}")
+
+    for message in messages:
+        try:
+            logger.info(f"Processing notify_overdue_borrowings")
+            success = send_telegram_message(message)
+            if not success:
+                logger.error("Failed to send Telegram notification")
+                raise Exception("Failed to send Telegram notification")
+        except Exception as exc:
+            logger.error(f"Error in notify_new_borrowing: {str(exc)}")
+            raise self.retry(exc=exc, countdown=60)

--- a/borrowing_service/utils.py
+++ b/borrowing_service/utils.py
@@ -1,0 +1,16 @@
+from datetime import date
+
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from borrowing_service.models import Borrowing
+
+
+def today_overdue_borrowings() -> (date, QuerySet):
+    today = timezone.now().date()
+    overdue_borrowings = Borrowing.objects.filter(
+        actual_return_date__isnull=True,
+        expected_return_date__lte=today
+    ).select_related("user", "book")
+
+    return today, overdue_borrowings

--- a/borrowing_service/utils.py
+++ b/borrowing_service/utils.py
@@ -9,8 +9,7 @@ from borrowing_service.models import Borrowing
 def today_overdue_borrowings() -> (date, QuerySet):
     today = timezone.now().date()
     overdue_borrowings = Borrowing.objects.filter(
-        actual_return_date__isnull=True,
-        expected_return_date__lte=today
+        actual_return_date__isnull=True, expected_return_date__lte=today
     ).select_related("user", "book")
 
     return today, overdue_borrowings


### PR DESCRIPTION
This PR is for discussion, it's not quite ready

  - Do we place this task in borrowing_service? I guess if we're querying the db for borrowings, we may as well put it there and import send_message from notifications
  
  - Maybe we could move the logic of calling the send_message to some shared function, so we don't have to repeat try: succes = ... each time
  
Calling it directly seems to work  
![image](https://github.com/user-attachments/assets/1af9c8e9-4a02-4c4f-a3fd-449cccd016a6)
