### PR TITLE
Add task to expire payments

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -179,6 +179,10 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": 60,  # 86400 seconds = 24 hours (daily)
         # 'schedule': crontab(hour=9, minute=0),  # Every day at 9:00
     },
+    "expire-payments-every-minute": {
+        "task": "payment_service.tasks.expire_payments",
+        "schedule": 60,
+    }
 }
 
 # Stripe Settings

--- a/core/settings.py
+++ b/core/settings.py
@@ -182,7 +182,7 @@ CELERY_BEAT_SCHEDULE = {
     "expire-payments-every-minute": {
         "task": "payment_service.tasks.expire_payments",
         "schedule": 60,
-    }
+    },
 }
 
 # Stripe Settings

--- a/payment_service/tasks.py
+++ b/payment_service/tasks.py
@@ -1,0 +1,29 @@
+import logging
+
+from celery import shared_task
+
+from payment_service.models import Payment
+from payment_service.utils import expired_sessions
+
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3)
+def expire_payments(self):
+    """
+    This task finds Payments with expired Stripe Sessions
+    and sets their status to expired
+    """
+    now, payments_to_expire = expired_sessions()
+    count = payments_to_expire.count()
+
+    logger.info(f"Found {count} expired payment sessions")
+
+    try:
+        if payments_to_expire.exists():
+            payments_to_expire.update(status=Payment.Status.EXPIRED)
+            logger.info(f"Set {count} Payments as 'expired'")
+    except Exception as exc:
+        logger.error(f"Error in expire_payments: {str(exc)}")
+        raise self.retry(exc=exc, countdown=60)

--- a/payment_service/utils.py
+++ b/payment_service/utils.py
@@ -11,7 +11,6 @@ def expired_sessions() -> tuple[datetime, QuerySet]:
     return (
         current_time,
         Payment.objects.filter(
-        session_expires_at__lt=current_time,
-        status=Payment.Status.PENDING
-        )
+            session_expires_at__lt=current_time, status=Payment.Status.PENDING
+        ),
     )

--- a/payment_service/utils.py
+++ b/payment_service/utils.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from payment_service.models import Payment
+
+
+def expired_sessions() -> tuple[datetime, QuerySet]:
+    current_time = timezone.now()
+    return (
+        current_time,
+        Payment.objects.filter(
+        session_expires_at__lt=current_time,
+        status=Payment.Status.PENDING
+        )
+    )

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -99,7 +99,7 @@ class CancelPaymentView(APIView):
             {
                 "message": "Payment was canceled. No charges were made.",
             },
-            status=status.HTTP_200_OK
+            status=status.HTTP_200_OK,
         )
 
 
@@ -143,7 +143,6 @@ class RenewStripeSessionView(APIView):
                 mode="payment",
                 success_url=success_url,
                 cancel_url=cancel_url,
-
             )
 
             try:
@@ -160,7 +159,7 @@ class RenewStripeSessionView(APIView):
 
                     payment.save()
 
-            except Exception as e:
+            except Exception:
                 return Response(
                     {"error": "Failed to update payment session."},
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -168,9 +167,9 @@ class RenewStripeSessionView(APIView):
             return Response(
                 {
                     "message": "Payment session renewed",
-                    "session_url": payment.session_url
+                    "session_url": payment.session_url,
                 },
-                status=status.HTTP_200_OK
+                status=status.HTTP_200_OK,
             )
 
         except stripe.error.StripeError as e:


### PR DESCRIPTION
This task runs every minute, gets all Payments with 'session_expires_at' < now, and updates their status to EXPIRED.
