### PR TITLE
Add renew stripe endpoint, refactor stripe session creation

### DIFF
--- a/payment_service/urls.py
+++ b/payment_service/urls.py
@@ -5,6 +5,7 @@ from payment_service.views import (
     DetailPaymentView,
     SuccessPaymentView,
     CancelPaymentView,
+    RenewStripeSessionView,
 )
 
 urlpatterns = [
@@ -12,6 +13,7 @@ urlpatterns = [
     path("<int:pk>/", DetailPaymentView.as_view()),
     path("success/", SuccessPaymentView.as_view(), name="payment-success"),
     path("cancel/", CancelPaymentView.as_view(), name="payment-cancel"),
+    path("renew/", RenewStripeSessionView.as_view(), name="renew"),
 ]
 
 app_name = "payment_service"

--- a/payment_service/utils.py
+++ b/payment_service/utils.py
@@ -37,7 +37,7 @@ def create_payment_session(borrowing, request, payment_type=Payment.Type.PAYMENT
     if payment_type == Payment.Type.PAYMENT:
         money_to_pay = Decimal(
             borrowing.book.daily_fee
-            * (borrowing.actual_return_date - borrowing.borrow_date).days
+            * (borrowing.expected_return_date - borrowing.borrow_date).days
         )
         payment_description = f"Book rental: {borrowing.book.title}"
 

--- a/payment_service/utils.py
+++ b/payment_service/utils.py
@@ -33,7 +33,6 @@ def create_payment_session(borrowing, request, payment_type=Payment.Type.PAYMENT
     Returns:
         tuple: (Payment object, Stripe session URL)
     """
-    stripe.api_key = settings.STRIPE_SECRET_KEY
 
     if payment_type == Payment.Type.PAYMENT:
         money_to_pay = Decimal(
@@ -57,25 +56,9 @@ def create_payment_session(borrowing, request, payment_type=Payment.Type.PAYMENT
     cancel_url = request.build_absolute_uri(reverse("payment_service:payment-cancel"))
 
     try:
-        checkout_session = stripe.checkout.Session.create(
-            payment_method_types=["card"],
-            line_items=[
-                {
-                    "price_data": {
-                        "currency": "usd",
-                        "product_data": {
-                            "name": payment_description,
-                        },
-                        "unit_amount": int(money_to_pay * 100),
-                    },
-                    "quantity": 1,
-                },
-            ],
-            mode="payment",
-            success_url=success_url,
-            cancel_url=cancel_url,
+        checkout_session = create_stripe_session(
+            payment_description, money_to_pay, success_url, cancel_url
         )
-
     except stripe.error.StripeError as e:
         raise e
 
@@ -90,3 +73,26 @@ def create_payment_session(borrowing, request, payment_type=Payment.Type.PAYMENT
     )
 
     return payment, checkout_session.url
+
+
+def create_stripe_session(product_description, money_to_pay, success_url, cancel_url):
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+
+    return stripe.checkout.Session.create(
+        payment_method_types=["card"],
+        line_items=[
+            {
+                "price_data": {
+                    "currency": "usd",
+                    "product_data": {
+                        "name": product_description,
+                    },
+                    "unit_amount": int(money_to_pay * 100),
+                },
+                "quantity": 1,
+            },
+        ],
+        mode="payment",
+        success_url=success_url,
+        cancel_url=cancel_url,
+    )

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -1,14 +1,16 @@
 import stripe
 from django.conf import settings
+from django.db import transaction
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from rest_framework import viewsets, status, generics
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from payment_service.models import Payment
+from payment_service.models import Payment, datetime_from_timestamp
 from payment_service.serializers import PaymentSerializer, PaymentListSerializer
-
+from payment_service.utils import create_stripe_session
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
 
@@ -95,3 +97,60 @@ class SuccessPaymentView(APIView):
 class CancelPaymentView(APIView):
     def get(self, request, *args, **kwargs):
         return Response({"message": "Payment was canceled. No charges were made."})
+
+
+class RenewStripeSessionView(APIView):
+
+    def post(self, request, payment_id):
+        payment = get_object_or_404(Payment, id=payment_id)
+        if payment.status != payment.Status.EXPIRED:
+            return Response(
+                {
+                    "error": "Payment is not expired",
+                    "status": status.HTTP_400_BAD_REQUEST,
+                }
+            )
+
+        success_url = request.build_absolute_uri(
+            reverse("payment_service:payment-success")
+            + "?session_id={CHECKOUT_SESSION_ID}"
+        )
+        cancel_url = request.build_absolute_uri(
+            reverse("payment_service:payment-cancel")
+        )
+
+        try:
+            new_session = create_stripe_session(
+                f"{payment.type} #{payment.id}",
+                payment.money_to_pay,
+                success_url,
+                cancel_url,
+            )
+        except stripe.error.StripeError as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            with transaction.atomic():
+                payment.session_url = new_session.get("url")
+                payment.session_id = new_session.get("id")
+
+                expires_at_timestamp = new_session.get("expires_at")
+                expires_at_datetime = datetime_from_timestamp(expires_at_timestamp)
+
+                payment.session_expires_at = expires_at_datetime
+
+                payment.status = Payment.Status.PENDING
+
+                payment.save()
+        except Exception:
+            return Response(
+                {"error": "Failed to update payment session."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response(
+            {
+                "message": "Payment session renewed",
+                "session_url": payment.session_url,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -106,8 +106,10 @@ class RenewStripeSessionView(APIView):
 
         if not payment_id:
             return Response(
-                {"error": "payment_id is required", },
-                status=status.HTTP_400_BAD_REQUEST
+                {
+                    "error": "payment_id is required",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         payment = get_object_or_404(Payment, id=payment_id)
@@ -119,10 +121,7 @@ class RenewStripeSessionView(APIView):
                 }
             )
 
-        if (
-            payment.borrowing.user.id != request.user.id
-            and not request.user.is_staff
-        ):
+        if payment.borrowing.user.id != request.user.id and not request.user.is_staff:
             return Response(
                 {"error": "You don't have permission to view this payment"},
                 status=status.HTTP_403_FORBIDDEN,

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -111,8 +111,8 @@ class RenewStripeSessionView(APIView):
                 }
             )
 
-        success_url = request.build_absolute_uri(
-            reverse("payment_service:payment-success")
+        success_url = (
+            request.build_absolute_uri(reverse("payment:stripe-success"))
             + "?session_id={CHECKOUT_SESSION_ID}"
         )
         cancel_url = request.build_absolute_uri(

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -40,7 +40,7 @@ class DetailPaymentView(generics.RetrieveAPIView):
 
 
 class SuccessPaymentView(APIView):
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         """
         Check successful Stripe payment and update payment status
         """


### PR DESCRIPTION
# An expired payment:
![image](https://github.com/user-attachments/assets/7e0bd87e-2a8c-448c-ac18-9f538cb6f8bf)
# POST request to paymets/renew with payment_id in request body
![image](https://github.com/user-attachments/assets/4b040205-3967-41be-bec6-5a9e61ef2449)
# Payment got new session
![image](https://github.com/user-attachments/assets/fcc5fc6c-1395-4cfa-941f-2e4f0be55a7c)

If session is not expired, returns 400 code

# Extracted Stripe session creation into create_stripe_session
Because session is created both on creating a new payment, and when renewing an expired one
