### PR TITLE
Fixed displaying payment_id & session_url for Borrowing creation

### DIFF
--- a/borrowing_service/serializers.py
+++ b/borrowing_service/serializers.py
@@ -24,14 +24,12 @@ class BorrowingBookSerializer(serializers.ModelSerializer):
 class BorrowingCreateSerializer(serializers.ModelSerializer):
     book = serializers.PrimaryKeyRelatedField(queryset=Book.objects.all())
     expected_return_date = serializers.DateField(required=True)
+    payment_id = serializers.IntegerField(read_only=True)
+    session_url = serializers.CharField(read_only=True)
 
     class Meta:
         model = Borrowing
-        fields = (
-            "id",
-            "expected_return_date",
-            "book",
-        )
+        fields = ("id", "expected_return_date", "book", "payment_id", "session_url")
 
     def validate(self, data):
         user = self.context["request"].user

--- a/borrowing_service/views.py
+++ b/borrowing_service/views.py
@@ -122,12 +122,9 @@ class BorrowingViewSet(
             )
             notify_new_borrowing.delay(borrowing.id)
 
+        borrowing.payment_id = payment.id if payment else None
+        borrowing.session_url = session_url if session_url else None
+
         response_data = BorrowingCreateSerializer(borrowing).data
-        response_data.update(
-            {
-                "payment_id": payment.id if payment else None,
-                "session_url": session_url if session_url else None,
-            }
-        )
 
         return Response(response_data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Displayed field for Payment after creation:
![create](https://github.com/user-attachments/assets/c3f03b5a-0406-46c1-9dc2-5fc662b66c23)

Displayed fields for Fine payment after return:
![return](https://github.com/user-attachments/assets/75cb043a-7ed1-445f-950f-c69161d1bc5c)
