### PR TITLE
fix: used borrowing id for tests

### DIFF
--- a/borrowing_service/tests/test_tasks.py
+++ b/borrowing_service/tests/test_tasks.py
@@ -48,7 +48,7 @@ class NotifyNewBorrowingTestCase(TestCase):
 
         expected_message = (
             "New Borrowing Created!\n"
-            "Borrowing ID: 1\n"
+            f"Borrowing ID: {self.borrowing.id}\n"
             "User: testuser@example.com\n"
             "Book: Test Book\n"
             f"Borrow Date: {datetime.date.today()}\n"


### PR DESCRIPTION
used self.borrowing.id for expected message in test_notify_new_borrowing_success