### PR TITLE
Fix docs for renew endpoint. Payment id is sent in request body

### DIFF
--- a/payment_service/schemas.py
+++ b/payment_service/schemas.py
@@ -1,6 +1,6 @@
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter,
+    OpenApiParameter, OpenApiExample,
 )
 
 from payment_service.serializers import PaymentSerializer, PaymentListSerializer
@@ -160,15 +160,25 @@ renew_stripe_session_schema = extend_schema(
                 "type": "object",
                 "properties": {
                     "payment_id": {
-                        "type": "string",
+                        "type": "integer",
+                        "format": "int32",
                         "description": "Stripe Payment ID",
-                        "example": "pi_123456789",
+                        "example": 1,
                     }
                 },
                 "required": ["payment_id"],
             }
         }
     },
+    examples=[
+        OpenApiExample(
+            "Request Example",
+            summary="Example request body",
+            description="This is how you should send the request.",
+            value={"payment_id": 1},  # Explicitly showing integer value
+            request_only=True,  # Ensures it's applied to request, not response
+        )
+    ],
     responses={
         200: {
             "description": "Payment session renewed successfully",

--- a/payment_service/schemas.py
+++ b/payment_service/schemas.py
@@ -154,14 +154,21 @@ cansel_payment_schema = extend_schema(
 )
 
 renew_stripe_session_schema = extend_schema(
-    parameters=[
-        OpenApiParameter(
-            name="session_id",
-            description="Stripe Checkout Session ID",
-            required=True,
-            type=str,
-        ),
-    ],
+    request={
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "payment_id": {
+                        "type": "string",
+                        "description": "Stripe Payment ID",
+                        "example": "pi_123456789",
+                    }
+                },
+                "required": ["payment_id"],
+            }
+        }
+    },
     responses={
         200: {
             "description": "Payment session renewed successfully",

--- a/payment_service/schemas.py
+++ b/payment_service/schemas.py
@@ -1,6 +1,7 @@
 from drf_spectacular.utils import (
     extend_schema,
-    OpenApiParameter, OpenApiExample,
+    OpenApiParameter,
+    OpenApiExample,
 )
 
 from payment_service.serializers import PaymentSerializer, PaymentListSerializer


### PR DESCRIPTION
Also added an example of sending "payment_id"