### PR TITLE
Fix 'api' prefix repetition in core.urls

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -3,18 +3,25 @@ from django.urls import path, include
 from drf_spectacular.views import SpectacularSwaggerView, SpectacularAPIView
 
 urlpatterns = [
-    path("api/books/", include("book_service.urls", namespace="book_service")),
     path(
-        "api/borrowings/",
-        include("borrowing_service.urls", namespace="borrowing_service"),
-    ),
-    path("api/payments/", include("payment_service.urls", namespace="payment_service")),
-    path("api/users/", include("user.urls", namespace="user")),
-    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path(
-        "api/doc/swagger/",
-        SpectacularSwaggerView.as_view(url_name="schema"),
-        name="swagger-ui",
+        "api/",
+        include(
+            [
+                path("books/", include("book_service.urls", namespace="book_service")),
+                path(
+                    "borrowings/",
+                    include("borrowing_service.urls", namespace="borrowing_service"),
+                ),
+                path("payments/", include("payment_service.urls", namespace="payment_service")),
+                path("users/", include("user.urls", namespace="user")),
+                path("schema/", SpectacularAPIView.as_view(), name="schema"),
+                path(
+                    "doc/swagger/",
+                    SpectacularSwaggerView.as_view(url_name="schema"),
+                    name="swagger-ui",
+                ),
+            ]
+        )
     ),
     path("admin/", admin.site.urls),
     path("__debug__/", include("debug_toolbar.urls")),

--- a/core/urls.py
+++ b/core/urls.py
@@ -12,7 +12,10 @@ urlpatterns = [
                     "borrowings/",
                     include("borrowing_service.urls", namespace="borrowing_service"),
                 ),
-                path("payments/", include("payment_service.urls", namespace="payment_service")),
+                path(
+                    "payments/",
+                    include("payment_service.urls", namespace="payment_service"),
+                ),
                 path("users/", include("user.urls", namespace="user")),
                 path("schema/", SpectacularAPIView.as_view(), name="schema"),
                 path(
@@ -21,7 +24,7 @@ urlpatterns = [
                     name="swagger-ui",
                 ),
             ]
-        )
+        ),
     ),
     path("admin/", admin.site.urls),
     path("__debug__/", include("debug_toolbar.urls")),


### PR DESCRIPTION
Group api endpoints with shared api prefix