### PR TITLE
fix as e, redundand re-raise

### DIFF
--- a/notifications_service/utils.py
+++ b/notifications_service/utils.py
@@ -23,8 +23,8 @@ def send_telegram_message(message: str) -> bool:
             logger.error(f"Telegram API error: {response.text}")
             return False
         return True
-    except Exception as e:
-        logger.error(f"Failed to send Telegram message: {str(e)}")
+    except Exception as exception:
+        logger.error(f"Failed to send Telegram message: {str(exception)}")
         return False
 
 
@@ -39,11 +39,11 @@ def task_handler(max_retries=3, countdown=60):
                 result = func(self, *args, **kwargs)
                 logger.info(f"Task {func.__name__} completed successfully")
                 return result
-            except Exception as exc:
-                logger.error(f"Error in {func.__name__}: {str(exc)}")
-                if isinstance(exc, self.retry.__class__):
-                    raise exc
-                raise self.retry(exc=exc, max_retries=max_retries, countdown=countdown)
+            except Exception as exception:
+                logger.error(f"Error in {func.__name__}: {str(exception)}")
+                if isinstance(exception, self.retry.__class__):
+                    raise exception
+                raise self.retry(exc=exception, max_retries=max_retries, countdown=countdown)
 
         return wrapper
 

--- a/notifications_service/utils.py
+++ b/notifications_service/utils.py
@@ -43,7 +43,9 @@ def task_handler(max_retries=3, countdown=60):
                 logger.error(f"Error in {func.__name__}: {str(exception)}")
                 if isinstance(exception, self.retry.__class__):
                     raise exception
-                raise self.retry(exc=exception, max_retries=max_retries, countdown=countdown)
+                raise self.retry(
+                    exc=exception, max_retries=max_retries, countdown=countdown
+                )
 
         return wrapper
 

--- a/payment_service/utils.py
+++ b/payment_service/utils.py
@@ -60,7 +60,6 @@ def create_payment_session(borrowing, request, payment_type=Payment.Type.PAYMENT
         payment_description, money_to_pay, success_url, cancel_url
     )
 
-
     payment = Payment.objects.create(
         borrowing=borrowing,
         status=Payment.Status.PENDING,

--- a/payment_service/utils.py
+++ b/payment_service/utils.py
@@ -56,12 +56,10 @@ def create_payment_session(borrowing, request, payment_type=Payment.Type.PAYMENT
     )
     cancel_url = request.build_absolute_uri(reverse("payment_service:payment-cancel"))
 
-    try:
-        checkout_session = create_stripe_session(
-            payment_description, money_to_pay, success_url, cancel_url
-        )
-    except stripe.error.StripeError as e:
-        raise e
+    checkout_session = create_stripe_session(
+        payment_description, money_to_pay, success_url, cancel_url
+    )
+
 
     payment = Payment.objects.create(
         borrowing=borrowing,

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -106,8 +106,8 @@ class SuccessPaymentView(APIView):
                     }
                 )
 
-        except stripe.error.StripeError as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except stripe.error.StripeError as error:
+            return Response({"error": str(error)}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class CancelPaymentView(APIView):
@@ -162,8 +162,8 @@ class RenewStripeSessionView(APIView):
                 success_url,
                 cancel_url,
             )
-        except stripe.error.StripeError as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except stripe.error.StripeError as error:
+            return Response({"error": str(error)}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             with transaction.atomic():

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -107,7 +107,9 @@ class SuccessPaymentView(APIView):
                 )
 
         except stripe.error.StripeError as exception:
-            return Response({"error": str(exception)}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": str(exception)}, status=status.HTTP_400_BAD_REQUEST
+            )
 
 
 class CancelPaymentView(APIView):
@@ -163,7 +165,9 @@ class RenewStripeSessionView(APIView):
                 cancel_url,
             )
         except stripe.error.StripeError as exception:
-            return Response({"error": str(exception)}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": str(exception)}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             with transaction.atomic():

--- a/payment_service/views.py
+++ b/payment_service/views.py
@@ -106,8 +106,8 @@ class SuccessPaymentView(APIView):
                     }
                 )
 
-        except stripe.error.StripeError as error:
-            return Response({"error": str(error)}, status=status.HTTP_400_BAD_REQUEST)
+        except stripe.error.StripeError as exception:
+            return Response({"error": str(exception)}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class CancelPaymentView(APIView):
@@ -162,8 +162,8 @@ class RenewStripeSessionView(APIView):
                 success_url,
                 cancel_url,
             )
-        except stripe.error.StripeError as error:
-            return Response({"error": str(error)}, status=status.HTTP_400_BAD_REQUEST)
+        except stripe.error.StripeError as exception:
+            return Response({"error": str(exception)}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             with transaction.atomic():


### PR DESCRIPTION
Since
```python
2. ось такі скорочення не потрібні except stripe.error.StripeError as e 
```

But we kinda need the detailed error info(?), renamed 'as e' to 'as exception'

Also, there was a redundand re-raise of stripe error in payment_service.utils.create_payment_session, removed that